### PR TITLE
Update for julia 1.0 / 0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,4 @@ notifications:
 #  - julia -e 'Pkg.clone(pwd()); Pkg.build("Example"); Pkg.test("Example"; coverage=true)';
 
 after_success:
-  - julia -e 'if VERSION >= v"0.7.0-" using Pkg end; cd(Pkg.dir("Example")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';
-#  - julia -e 'if VERSION >= v"0.7.0-" using Pkg end; cd(Pkg.dir("Example")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())';
-<Paste>
+  - julia -e 'using Pkg; cd(Pkg.dir("MLPreprocessing")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,29 @@
-# Documentation: http://docs.travis-ci.com/user/languages/julia/
 language: julia
+
 os:
-  - linux
   - osx
+  - linux
+
 julia:
-  - 0.6
+  - 0.7
+  - 1.0
+  - 1.1
   - nightly
-matrix:
-  allow_failures:
-    - julia: nightly
-git:
-  depth: 5000
+
+# # Uncomment the following lines to allow failures on nightly julia
+# # (tests will run but not make your overall status red)
+# matrix:
+#   allow_failures:
+#   - julia: nightly
+
 notifications:
   email: false
-# uncomment the following lines to override the default test script
-#script:
+
+#script: # the default script is equivalent to the following
 #  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-#  - julia -e 'Pkg.clone(pwd()); Pkg.build("MLPreprocessing"); Pkg.test("MLPreprocessing")'
+#  - julia -e 'Pkg.clone(pwd()); Pkg.build("Example"); Pkg.test("Example"; coverage=true)';
+
 after_success:
-  - julia -e 'Pkg.add("Documenter")'
-  - julia -e 'cd(Pkg.dir("MLPreprocessing")); include(joinpath("docs", "make.jl"))'
-  # push coverage results to Coveralls
-  # - julia -e 'if VERSION >= v"0.6.0-alpha"; cd(Pkg.dir("MLPreprocessing")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder()); end'
-  - julia -e 'cd(Pkg.dir("MLPreprocessing")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder()); end'
-  # push coverage results to Codecov
-  #  - julia -e 'cd(Pkg.dir("MLPreprocessing")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+  - julia -e 'if VERSION >= v"0.7.0-" using Pkg end; cd(Pkg.dir("Example")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';
+#  - julia -e 'if VERSION >= v"0.7.0-" using Pkg end; cd(Pkg.dir("Example")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())';
+<Paste>

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,17 @@
+name = "MLPreprocessing"
+uuid = "270893ea-b48f-5b4f-bac8-adb34c91318c"
+
+[deps]
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+LearnBase = "7f8f8fb0-2700-5f03-b4bd-41f8cfc144b6"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+
+[compat]
+julia = "0.7, 1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,8 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 julia = "0.7, 1"
+DataFrames = ">= 0.16"
+
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ functions `fit()`, `transform()` and `fit_transform()` as shown below.
 `X`         :  Data of type Matrix or `DataFrame`.
 
 `μ`         :  Vector or scalar describing the translation.
-               Defaults to mean(X, obsdim)
+               Defaults to mean(X; dims=obsdim)
 
 `σ`         :  Vector or scalar describing the scale.
-               Defaults to std(X, obsdim)
+               Defaults to std(X; dims=obsdim)
 
 `obsdim`    :  Specify which axis corresponds to observations.
                Defaults to obsdim=2 (observations are columns of matrix)
@@ -46,7 +46,7 @@ functions `fit()`, `transform()` and `fit_transform()` as shown below.
                with index 1 and 3 only (if obsdim=1, else rows 1 and 3)
 
 Note on DataFrames:
-Columns containing `NA` values are skipped.
+Columns containing `missing` values are skipped.
 Columns containing non numeric elements are skipped.
 
 Examples:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.7
 StatsBase 0.13
-LearnBase 0.1.5 0.2.0
-DataFrames 0.11
+LearnBase
+DataFrames 0.9

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.7
 StatsBase 0.13
 LearnBase
-DataFrames 0.9
+DataFrames 0.16

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,20 @@
 environment:
   matrix:
-    - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
-    - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
-    - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-    - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+  - julia_version: 0.7
+  - julia_version: 1.0
+  - julia_version: 1
+  - julia_version: nightly
+
+platform:
+  - x86 # 32-bit
+  - x64 # 64-bit
+
+# # Uncomment the following lines to allow failures on nightly julia
+# # (tests will run but not make your overall status red)
+# matrix:
+#   allow_failures:
+#   - julia_version: nightly
+
 branches:
   only:
     - master
@@ -15,25 +26,19 @@ notifications:
     on_build_failure: false
     on_build_status_changed: false
 
-matrix:
-  allow_failures:
-    - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-    - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
-
 install:
-  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
-# Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile(
-        $env:JULIA_URL,
-        "C:\projects\julia-binary.exe")
-# Run installer silently, output to C:\projects\julia
-  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
 
 build_script:
-# Need to convert from shallow to complete for Pkg.clone to work
-  - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "versioninfo();
-      Pkg.clone(pwd(), \"MLPreprocessing\"); Pkg.build(\"MLPreprocessing\")"
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
 
 test_script:
-  - C:\projects\julia\bin\julia -e "Pkg.test(\"MLPreprocessing\")"
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"
+
+# # Uncomment to support code coverage upload. Should only be enabled for packages
+# # which would have coverage gaps without running on Windows
+# on_success:
+#   - echo "%JL_CODECOV_SCRIPT%"
+#   - C:\julia\bin\julia -e "%JL_CODECOV_SCRIPT%"

--- a/src/MLPreprocessing.jl
+++ b/src/MLPreprocessing.jl
@@ -1,6 +1,7 @@
 __precompile__()
 module MLPreprocessing
 
+using Statistics
 using StatsBase
 using LearnBase
 using DataFrames

--- a/src/basis_expansion.jl
+++ b/src/basis_expansion.jl
@@ -48,13 +48,13 @@ function expand_poly(x::AbstractVector, degree::Integer, ::ObsDim.Last)
 end
 
 function expand_poly(
-    x::AbstractVector,
+    x::AbstractVector{T},
     degree::Integer,
     ::ObsDim.Constant{2} = ObsDim.Constant{2}()
-)
+) where T
 
     n = length(x)
-    X = float.(zeros(T, (degree, n)))
+    X = zeros(float(T), (degree, n))
     for i in 1:n
         for d in 1:degree
             @inbounds X[d, i] += float(x[i])^d
@@ -64,13 +64,13 @@ function expand_poly(
 end
 
 function expand_poly(
-    x::AbstractVector,
+    x::AbstractVector{T},
     degree::Integer,
     ::ObsDim.Constant{1}
-)
+) where T
 
     n = length(x)
-    X = float.(zeros(T, (degree, n)))
+    X = zeros(float(T), (n, degree))
     for d in 1:degree
         for i in 1:n
             @inbounds X[i, d] += float(x[i])^d

--- a/src/basis_expansion.jl
+++ b/src/basis_expansion.jl
@@ -54,7 +54,7 @@ function expand_poly(
 ) where T
 
     n = length(x)
-    X = zeros(float(T), (degree, n))
+    X = zeros(floattype(T), (degree, n))
     for i in 1:n
         for d in 1:degree
             @inbounds X[d, i] += float(x[i])^d
@@ -70,7 +70,7 @@ function expand_poly(
 ) where T
 
     n = length(x)
-    X = zeros(float(T), (n, degree))
+    X = zeros(floattype(T), (n, degree))
     for d in 1:degree
         for i in 1:n
             @inbounds X[i, d] += float(x[i])^d
@@ -78,3 +78,8 @@ function expand_poly(
     end
     return X
 end
+
+
+floattype(::Type{T}) where T = float(T)
+floattype(::Type{Missing}) = Missing
+floattype(U::Union) = Union{floattype(U.a), floattype(U.b)}

--- a/src/basis_expansion.jl
+++ b/src/basis_expansion.jl
@@ -47,24 +47,34 @@ function expand_poly(x::AbstractVector, degree::Integer, ::ObsDim.Last)
     expand_poly(x, degree, ObsDim.Constant{2}())
 end
 
-function expand_poly(x::AbstractVector{T}, degree::Integer, ::ObsDim.Constant{2} = ObsDim.Constant{2}()) where {T}
+function expand_poly(
+    x::AbstractVector,
+    degree::Integer,
+    ::ObsDim.Constant{2} = ObsDim.Constant{2}()
+)
+
     n = length(x)
-    X = zeros(T, (degree, n))
-    @inbounds for i in 1:n
+    X = float.(zeros(T, (degree, n)))
+    for i in 1:n
         for d in 1:degree
-            X[d, i] += x[i]^(d)
+            @inbounds X[d, i] += float(x[i])^d
         end
     end
-    X
+    return X
 end
 
-function expand_poly(x::AbstractVector{T}, degree::Integer, ::ObsDim.Constant{1}) where {T}
+function expand_poly(
+    x::AbstractVector,
+    degree::Integer,
+    ::ObsDim.Constant{1}
+)
+
     n = length(x)
-    X = zeros(T, (n, degree))
-    @inbounds for d in 1:degree
+    X = float.(zeros(T, (degree, n)))
+    for d in 1:degree
         for i in 1:n
-            X[i, d] += x[i]^(d)
+            @inbounds X[i, d] += float(x[i])^d
         end
     end
-    X
+    return X
 end

--- a/src/center.jl
+++ b/src/center.jl
@@ -85,7 +85,7 @@ function center!(X::AbstractMatrix,
     center!(X, ObsDim.Constant{2}(), operate_on)
 end
 
-function center!(X::AbstractArray,
+function center!(X::AbstractMatrix,
                  obsdim::ObsDim.Constant{M},
                  operate_on::AbstractVector) where {M}
     μ = vec(mean(X; dims=M))[operate_on]

--- a/src/scaleselection.jl
+++ b/src/scaleselection.jl
@@ -25,10 +25,10 @@ end
 function valid_columns(D::AbstractDataFrame)
     valid_colnames = Symbol[]
     for colname in names(D)
-        if (eltype(D[colname]) <: Real) & !any(ismissing, D[colname])
+        if (eltype(D[colname]) <: Union{Real,Missing}) & !any(ismissing, D[colname])
             push!(valid_colnames, colname)
         else
-            warn("Skipping \"$colname\" because it either contains missing values or is not of type <: Real")
+            @warn("Skipping \"$colname\" because it either contains missing or is not of type <: Real")
         end
     end
     valid_colnames
@@ -37,12 +37,11 @@ end
 function valid_columns(D::AbstractDataFrame, colnames)
     valid_colnames = Symbol[]
     for colname in colnames
-        if (eltype(D[colname]) <: Real) & !(any(ismissing, D[colname]))
+        if (eltype(D[colname]) <: Union{Real,Missing}) & !(any(ismissing, D[colname]))
             push!(valid_colnames, colname)
         else
-            warn("Skipping \"$colname\" because it either contains missing values or is not of type <: Real")
+            @warn("Skipping \"$colname\" because it either contains missing or is not of type <: Real")
         end
     end
     valid_colnames
 end
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using MLPreprocessing
 using DataFrames
 using Test
+using Statistics
 
 tests = [
     "tst_expand.jl"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using MLPreprocessing
 using DataFrames
-using Base.Test
+using Test
 
 tests = [
     "tst_expand.jl"

--- a/test/tst_center.jl
+++ b/test/tst_center.jl
@@ -1,73 +1,72 @@
 X = collect(Float64, reshape(1:40, 10, 4))
 x = rand(10) * 10
 
-D = DataFrame(A=rand(10), B=collect(1:10), C=[hex(x) for x in 11:20])
-D_NA = deepcopy(D)
-allowmissing!(D_NA, :A)
+D = DataFrame(A=rand(10), B=1:10, C=string.(11:20; base=16))
+D_NA = allowmissing!(copy(D))
 D_NA[1, :A] = missing
 
 @testset "Array" begin
     XX = deepcopy(X)
     mu = center!(XX, obsdim=1)
-    @test sum(abs.(mean(XX, 1))) == 0
-    @test all(std(XX, 1) .== std(X, 1))
-    @test all(mu .== vec(mean(X, 1)))
+    @test sum(abs.(mean(XX; dims=1))) == 0
+    @test all(std(XX; dims=1) .== std(X; dims=1))
+    @test all(mu .== vec(mean(X; dims=1)))
 
     XX = deepcopy(X)
     mu = center!(XX, ObsDim.First())
-    @test sum(abs.(mean(XX, 1))) == 0
-    @test all(std(XX, 1) .== std(X, 1))
-    @test all(mu .== vec(mean(X, 1)))
+    @test sum(abs.(mean(XX; dims=1))) == 0
+    @test all(std(XX; dims=1) .== std(X; dims=1))
+    @test all(mu .== vec(mean(X; dims=1)))
 
     XX = deepcopy(X)
     mu = center!(XX, ObsDim.Last())
-    @test sum(abs.(mean(XX, 2))) == 0
-    @test all(std(XX, 2) .== std(X, 2))
-    @test all(mu .== vec(mean(X, 2)))
+    @test sum(abs.(mean(XX; dims=2))) == 0
+    @test all(std(XX; dims=2) .== std(X; dims=2))
+    @test all(mu .== vec(mean(X; dims=2)))
 
     XX = deepcopy(X)
     mu = center!(XX)
-    @test sum(abs.(mean(XX, 2))) == 0
-    @test all(std(XX, 2) .== std(X, 2))
-    @test all(mu .== vec(mean(X, 2)))
+    @test sum(abs.(mean(XX; dims=2))) == 0
+    @test all(std(XX; dims=2) .== std(X; dims=2))
+    @test all(mu .== vec(mean(X; dims=2)))
 
     XX = deepcopy(X)
-    mu = vec(mean(X, 1))
+    mu = vec(mean(X; dims=1))
     center!(XX, mu, obsdim=1)
-    @test sum(abs.(mean(XX, 1))) == 0
-    @test all(std(XX, 1) .== std(X, 1))
+    @test sum(abs.(mean(XX; dims=1))) == 0
+    @test all(std(XX; dims=1) .== std(X; dims=1))
 
     XX = deepcopy(X)
-    mu = vec(mean(X, 1))
+    mu = vec(mean(X; dims=1))
     center!(XX, mu, ObsDim.First())
-    @test sum(abs.(mean(XX, 1))) == 0
-    @test all(std(XX, 1) .== std(X, 1))
+    @test sum(abs.(mean(XX; dims=1))) == 0
+    @test all(std(XX; dims=1) .== std(X; dims=1))
 
     XX = deepcopy(X)
-    mu = vec(mean(XX, 2))
+    mu = vec(mean(XX; dims=2))
     center!(XX, mu, obsdim=2)
-    @test sum(abs.(mean(XX, 2))) == 0
-    @test all(std(XX, 2) .== std(X, 2))
+    @test sum(abs.(mean(XX; dims=2))) == 0
+    @test all(std(XX; dims=2) .== std(X; dims=2))
 
     XX = deepcopy(X)
-    mu = vec(mean(XX, 2))
+    mu = vec(mean(XX; dims=2))
     center!(XX, mu, ObsDim.Last())
-    @test sum(abs.(mean(XX, 2))) == 0
-    @test all(std(XX, 2) .== std(X, 2))
+    @test sum(abs.(mean(XX; dims=2))) == 0
+    @test all(std(XX; dims=2) .== std(X; dims=2))
 
     XX = deepcopy(X)
-    mu = vec(mean(X[:,[1,3]], 1))
+    mu = vec(mean(X[:,[1,3]]; dims=1))
     center!(XX, mu, obsdim=1, operate_on=[1, 3])
-    @test sum(abs.(mean(XX[:,[1,3]], 1))) == 0
+    @test sum(abs.(mean(XX[:,[1,3]]; dims=1))) == 0
     @test all(XX[:,2] .== X[:,2])
-    @test all(std(XX, 1) .== std(X, 1))
+    @test all(std(XX; dims=1) .== std(X; dims=1))
 
     XX = deepcopy(X)
-    mu = vec(mean(X[[1,3],:], 2))
+    mu = vec(mean(X[[1,3],:]; dims=2))
     center!(XX, mu, obsdim=2, operate_on=[1, 3])
-    @test sum(abs.(mean(XX[[1,3],:], 2))) == 0
+    @test sum(abs.(mean(XX[[1,3],:]; dims=2))) == 0
     @test all(XX[2,:] .== X[2,:])
-    @test all(std(XX, 2) .== std(X, 2))
+    @test all(std(XX; dims=2) .== std(X; dims=2))
     println()
 
     xx = deepcopy(x)
@@ -80,12 +79,12 @@ D_NA[1, :A] = missing
     @test mean(xx) <= 10e-10
 
     xx = deepcopy(x)
-    mu = ones(xx)
+    mu = ones(size(xx))
     center!(xx, mu)
     @test mean(xx) - mean(x) ≈ -1
 
     xx = deepcopy(x)
-    mu = ones(xx)
+    mu = ones(size(xx))
     center!(xx, mu)
     @test mean(xx) - mean(x) ≈ -1
 end
@@ -137,7 +136,7 @@ end
     @test abs.(mean(DD[:A])) <= 10e-10
     @test abs.(mean(DD[:B])) <= 10e-10
     @test all(DD[:C] .== D[:C])
-
+    
     DD = deepcopy(D_NA)
     center!(DD)
     @test all(DD[2:end, :A] .== D[2:end, :A])

--- a/test/tst_fixedrangescaler.jl
+++ b/test/tst_fixedrangescaler.jl
@@ -2,9 +2,9 @@ X = collect(Float64, reshape(1:40, 10, 4))
 x = rand(10) * 10
 w = collect(Float64, 1:10)
 
-D = DataFrame(A=rand(10), B=collect(1:10), C=[hex(x) for x in 11:20])
-D_NA = deepcopy(D)
-D_NA[1, :A] = NA
+D = DataFrame(A=rand(10), B=1:10, C=string.(11:20; base=16))
+D_NA = allowmissing!(copy(D))
+D_NA[1, :A] = missing
 @testset "Array" begin
     scaler = FixedRangeScaler(X)
     XX = transform(X, scaler)
@@ -29,9 +29,9 @@ D_NA[1, :A] = NA
     scaler = FixedRangeScaler(X, -2, 2)
     XX = transform(X, scaler)
     @test mean(XX[:,end]) ≈ 2
-    @test mean(XX[:,1]) ≈ -2 
-    @test maximum(XX) == 2 
-    @test minimum(XX) == -2 
+    @test mean(XX[:,1]) ≈ -2
+    @test maximum(XX) == 2
+    @test minimum(XX) == -2
 
     scaler = fit(FixedRangeScaler, X)
     XX = transform(X, scaler)
@@ -52,39 +52,39 @@ D_NA[1, :A] = NA
     @test mean(XX[:,end]) ≈ 2
     @test mean(XX[:,1]) ≈ -2
     @test maximum(XX) == 2
-    @test minimum(XX) == -2 
+    @test minimum(XX) == -2
 
     XX, scaler = fit_transform(FixedRangeScaler, X, -2, 2)
     @test mean(XX[:,end]) ≈ 2
     @test mean(XX[:,1]) ≈ -2
     @test maximum(XX) == 2
-    @test minimum(XX) == -2 
+    @test minimum(XX) == -2
 
     XX = deepcopy(X)
     scaler = fit_transform!(FixedRangeScaler, XX, -2, 2)
     @test mean(XX[:,end]) ≈ 2
     @test mean(XX[:,1]) ≈ -2
     @test maximum(XX) == 2
-    @test minimum(XX) == -2 
+    @test minimum(XX) == -2
 
     scaler = fit(FixedRangeScaler, X, -2, 2, obsdim=1)
     XX = transform(X, scaler)
-    @test mean(XX[1,:]) ≈ -2 
+    @test mean(XX[1,:]) ≈ -2
     @test mean(XX[end,:]) ≈ 2
     @test maximum(XX) == 2
     @test minimum(XX) == -2
 
     scaler = fit(FixedRangeScaler, X, -2, 2, obsdim=2)
     XX = transform(X, scaler)
-    @test mean(minimum(XX, 2)) ≈ -2 
-    @test mean(maximum(XX, 2)) ≈ 2 
+    @test mean(minimum(XX; dims=2)) ≈ -2
+    @test mean(maximum(XX; dims=2)) ≈ 2
     @test maximum(XX) == 2
     @test minimum(XX) == -2
 
     scaler = fit(FixedRangeScaler, X, -2, 2, obsdim=1, operate_on=[1,2])
     XX = transform(X, scaler)
-    @test mean(minimum(XX[:,[1,2]], 1)) ≈ -2 
-    @test mean(maximum(XX[:,[1,2]], 1)) ≈ 2 
+    @test mean(minimum(XX[:,[1,2]], dims=1)) ≈ -2
+    @test mean(maximum(XX[:,[1,2]], dims=1)) ≈ 2
     ww = deepcopy(w)
     transform!(ww, scaler)
     @test ww[1] == -2
@@ -92,60 +92,60 @@ D_NA[1, :A] = NA
 
     scaler = fit(FixedRangeScaler, X, -2, 2, obsdim=2, operate_on=[1,2])
     XX = transform(X, scaler)
-    @test mean(minimum(XX[[1,2],:], 2)) ≈ -2 
-    @test mean(maximum(XX[[1,2],:], 2)) ≈ 2 
+    @test mean(minimum(XX[[1,2],:], dims=2)) ≈ -2
+    @test mean(maximum(XX[[1,2],:], dims=2)) ≈ 2
 
     Xi = round.(Int, X)
     transform(Xi, scaler)
-    @test mean(minimum(XX[[1,2],:], 2)) ≈ -2 
-    @test mean(maximum(XX[[1,2],:], 2)) ≈ 2 
+    @test mean(minimum(XX[[1,2],:], dims=2)) ≈ -2
+    @test mean(maximum(XX[[1,2],:], dims=2)) ≈ 2
 
     scaler = fit(FixedRangeScaler, X, -2, 2, obsdim=2, operate_on=[1,2])
     XX = deepcopy(X)
     transform!(XX, scaler)
-    @test mean(minimum(XX[[1,2],:], 2)) ≈ -2 
-    @test mean(maximum(XX[[1,2],:], 2)) ≈ 2 
+    @test mean(minimum(XX[[1,2],:], dims=2)) ≈ -2
+    @test mean(maximum(XX[[1,2],:], dims=2)) ≈ 2
 
     XX = deepcopy(X)
     fixedrange!(XX)
-    @test all(maximum(XX, 2) .== ones(size(XX, 1)))
-    @test all(minimum(XX, 2) .== zeros(size(XX, 1)))
+    @test all(maximum(XX; dims=2) .== ones(size(XX, 1)))
+    @test all(minimum(XX; dims=2) .== zeros(size(XX, 1)))
 
     XX = deepcopy(X)
     fixedrange!(XX, ObsDim.Last(), collect(1:size(X,1)))
-    @test all(maximum(XX, 2) .== ones(size(XX, 1)))
-    @test all(minimum(XX, 2) .== zeros(size(XX, 1)))
+    @test all(maximum(XX; dims=2) .== ones(size(XX, 1)))
+    @test all(minimum(XX; dims=2) .== zeros(size(XX, 1)))
 
     XX = deepcopy(X)
     fixedrange!(XX, -2, 2)
-    @test all(maximum(XX, 2) .== ones(size(XX, 1)) .* 2)
-    @test all(minimum(XX, 2) .== ones(size(XX, 1)) .* -2)
+    @test all(maximum(XX; dims=2) .== ones(size(XX, 1)) .* 2)
+    @test all(minimum(XX; dims=2) .== ones(size(XX, 1)) .* -2)
 
     XX = deepcopy(X)
     fixedrange!(XX, 0, 1, ObsDim.First(), collect(1:size(X, 2)))
-    @test all(maximum(XX, 1) .== ones(size(XX, 2)))
-    @test all(minimum(XX, 1) .== zeros(size(XX, 2)))
+    @test all(maximum(XX; dims=1) .== ones(size(XX, 2)))
+    @test all(minimum(XX; dims=1) .== zeros(size(XX, 2)))
 
     XX = deepcopy(X)
     fixedrange!(XX, 0, 1, ObsDim.Last(), collect(1:size(X,1)))
-    @test all(maximum(XX, 2) .== ones(size(XX, 1)))
-    @test all(minimum(XX, 2) .== zeros(size(XX, 1)))
+    @test all(maximum(XX; dims=2) .== ones(size(XX, 1)))
+    @test all(minimum(XX; dims=2) .== zeros(size(XX, 1)))
 
     XX = deepcopy(X)
-    fixedrange!(XX, 0, 1, vec(minimum(XX, 2)), vec(maximum(XX, 2)))
-    @test all(maximum(XX, 2) .== ones(size(XX, 1)))
-    @test all(minimum(XX, 2) .== zeros(size(XX, 1)))
+    fixedrange!(XX, 0, 1, vec(minimum(XX; dims=2)), vec(maximum(XX; dims=2)))
+    @test all(maximum(XX; dims=2) .== ones(size(XX, 1)))
+    @test all(minimum(XX; dims=2) .== zeros(size(XX, 1)))
 
 
     XX = deepcopy(X)
-    fixedrange!(XX, 0, 1, vec(minimum(XX, 2)), vec(maximum(XX, 2)), ObsDim.Last(), collect(1:size(XX, 1)))
-    @test all(maximum(XX, 2) .== ones(size(XX, 1)))
-    @test all(minimum(XX, 2) .== zeros(size(XX, 1)))
+    fixedrange!(XX, 0, 1, vec(minimum(XX; dims=2)), vec(maximum(XX; dims=2)), ObsDim.Last(), collect(1:size(XX, 1)))
+    @test all(maximum(XX; dims=2) .== ones(size(XX, 1)))
+    @test all(minimum(XX; dims=2) .== zeros(size(XX, 1)))
 
     XX = deepcopy(X)
-    fixedrange!(XX, 0, 1, vec(minimum(XX, 2)), vec(maximum(XX, 2)), ObsDim.Constant{2}(), collect(1:size(XX, 1)))
-    @test all(maximum(XX, 2) .== ones(size(XX, 1)))
-    @test all(minimum(XX, 2) .== zeros(size(XX, 1)))
+    fixedrange!(XX, 0, 1, vec(minimum(XX; dims=2)), vec(maximum(XX; dims=2)), ObsDim.Constant{2}(), collect(1:size(XX, 1)))
+    @test all(maximum(XX; dims=2) .== ones(size(XX, 1)))
+    @test all(minimum(XX; dims=2) .== zeros(size(XX, 1)))
 
     xx = deepcopy(x)
     fixedrange!(xx)
@@ -158,141 +158,141 @@ D_NA[1, :A] = NA
     @test maximum(xx) == 1
 
     xx = deepcopy(x)
-    xmin = minimum(x, 2) .- 1
-    xmax = maximum(x, 2)
+    xmin = minimum(x; dims=2) .- 1
+    xmax = maximum(x; dims=2)
 
     xx = deepcopy(x)
     fixedrange!(xx, -1, 1, xmin, xmax, ObsDim.First(), collect(1:length(x)))
-    @test all(minimum(xx, 2) .== ones(length(x)))
-    @test all(maximum(xx, 2) .== ones(length(x)))
+    @test all(minimum(xx; dims=2) .== ones(length(x)))
+    @test all(maximum(xx; dims=2) .== ones(length(x)))
 
     xx = deepcopy(x)
     fixedrange!(xx, -1, 1, xmin, xmax, ObsDim.Last(), collect(1:length(x)))
-    @test all(minimum(xx, 2) .== ones(length(x)))
-    @test all(maximum(xx, 2) .== ones(length(x)))
+    @test all(minimum(xx; dims=2) .== ones(length(x)))
+    @test all(maximum(xx; dims=2) .== ones(length(x)))
 end
 
 
 @testset "DataFrame" begin
     scaler = FixedRangeScaler(D)
     DD = transform(D, scaler)
-    @test minimum(DD[:A]) == 0 
-    @test maximum(DD[:A]) == 1 
-    @test minimum(DD[:B]) == 0 
-    @test maximum(DD[:B]) == 1 
+    @test minimum(DD[:A]) == 0
+    @test maximum(DD[:A]) == 1
+    @test minimum(DD[:B]) == 0
+    @test maximum(DD[:B]) == 1
     
     scaler = fit(FixedRangeScaler, D)
     DD = transform(D, scaler)
-    @test minimum(DD[:A]) == 0 
-    @test maximum(DD[:A]) == 1 
-    @test minimum(DD[:B]) == 0 
-    @test maximum(DD[:B]) == 1 
+    @test minimum(DD[:A]) == 0
+    @test maximum(DD[:A]) == 1
+    @test minimum(DD[:B]) == 0
+    @test maximum(DD[:B]) == 1
 
     DD, scaler = fit_transform(FixedRangeScaler, D)
-    @test minimum(DD[:A]) == 0 
-    @test maximum(DD[:A]) == 1 
-    @test minimum(DD[:B]) == 0 
-    @test maximum(DD[:B]) == 1 
+    @test minimum(DD[:A]) == 0
+    @test maximum(DD[:A]) == 1
+    @test minimum(DD[:B]) == 0
+    @test maximum(DD[:B]) == 1
 
     DD = deepcopy(D)
     scaler = fit_transform!(FixedRangeScaler, DD)
-    @test minimum(DD[:A]) == 0 
-    @test maximum(DD[:A]) == 1 
-    @test minimum(DD[:B]) == 0 
-    @test maximum(DD[:B]) == 1 
+    @test minimum(DD[:A]) == 0
+    @test maximum(DD[:A]) == 1
+    @test minimum(DD[:B]) == 0
+    @test maximum(DD[:B]) == 1
 
     scaler = fit(FixedRangeScaler, D, -1, 1)
     DD = transform(D, scaler)
     @test minimum(DD[:A]) == -1
     @test maximum(DD[:A]) == 1
-    @test minimum(DD[:B]) == -1 
-    @test maximum(DD[:B]) == 1 
+    @test minimum(DD[:B]) == -1
+    @test maximum(DD[:B]) == 1
 
     DD, scaler = fit_transform(FixedRangeScaler, D, -1, 1)
     @test minimum(DD[:A]) == -1
     @test maximum(DD[:A]) == 1
-    @test minimum(DD[:B]) == -1 
-    @test maximum(DD[:B]) == 1 
+    @test minimum(DD[:B]) == -1
+    @test maximum(DD[:B]) == 1
 
     DD = deepcopy(D)
     scaler = fit_transform!(FixedRangeScaler, DD, -1, 1)
     @test minimum(DD[:A]) == -1
     @test maximum(DD[:A]) == 1
-    @test minimum(DD[:B]) == -1 
-    @test maximum(DD[:B]) == 1 
+    @test minimum(DD[:B]) == -1
+    @test maximum(DD[:B]) == 1
 
     scaler = FixedRangeScaler(D, -1, 1)
     DD = transform(D, scaler)
     @test minimum(DD[:A]) == -1
     @test maximum(DD[:A]) == 1
-    @test minimum(DD[:B]) == -1 
-    @test maximum(DD[:B]) == 1 
+    @test minimum(DD[:B]) == -1
+    @test maximum(DD[:B]) == 1
 
     scaler = fit(FixedRangeScaler, D, -1, 1, operate_on=[:A])
     DD = transform(D, scaler)
     @test minimum(DD[:A]) == -1
     @test maximum(DD[:A]) == 1
-    @test minimum(DD[:B]) == minimum(D[:B]) 
+    @test minimum(DD[:B]) == minimum(D[:B])
     @test maximum(DD[:B]) == maximum(D[:B])
 
     scaler = fit(FixedRangeScaler, D, -1, 1)
     DD = transform(D_NA, scaler)
-    @test isna(DD[1,:A])
+    @test ismissing(DD[1,:A])
     @test DD[end,:A] == D_NA[end,:A]
-    @test minimum(DD[:B]) == -1 
-    @test maximum(DD[:B]) == 1 
+    @test minimum(DD[:B]) == -1
+    @test maximum(DD[:B]) == 1
 
     scaler = fit(FixedRangeScaler, D, -1, 1, operate_on=[:A, :B])
     DD = transform(D_NA, scaler)
-    @test isna(DD[1,:A])
+    @test ismissing(DD[1,:A])
     @test DD[end,:A] == D_NA[end,:A]
-    @test minimum(DD[:B]) == -1 
-    @test maximum(DD[:B]) == 1 
+    @test minimum(DD[:B]) == -1
+    @test maximum(DD[:B]) == 1
 
     scaler = fit(FixedRangeScaler, D, -1, 1, operate_on=[:A, :B, :C])
     DD = transform(D_NA, scaler)
-    @test isna(DD[1,:A])
+    @test ismissing(DD[1,:A])
     @test DD[end,:A] == D_NA[end,:A]
-    @test minimum(DD[:B]) == -1 
-    @test maximum(DD[:B]) == 1 
+    @test minimum(DD[:B]) == -1
+    @test maximum(DD[:B]) == 1
 
     DD = deepcopy(D)
     scaler = fit(FixedRangeScaler, D, -1, 1, operate_on=[:A, :B])
     transform!(DD, scaler)
-    @test minimum(DD[:A]) == -1 
-    @test maximum(DD[:A]) == 1 
-    @test minimum(DD[:B]) == -1 
-    @test maximum(DD[:B]) == 1 
+    @test minimum(DD[:A]) == -1
+    @test maximum(DD[:A]) == 1
+    @test minimum(DD[:B]) == -1
+    @test maximum(DD[:B]) == 1
 
 
     DD = deepcopy(D)
     fixedrange!(DD)
-    @test minimum(DD[:A]) == 0 
-    @test maximum(DD[:A]) == 1 
-    @test minimum(DD[:B]) == 0 
-    @test maximum(DD[:B]) == 1 
+    @test minimum(DD[:A]) == 0
+    @test maximum(DD[:A]) == 1
+    @test minimum(DD[:B]) == 0
+    @test maximum(DD[:B]) == 1
 
     DD = deepcopy(D)
     fixedrange!(DD, -1, 1)
-    @test minimum(DD[:A]) == -1 
-    @test maximum(DD[:A]) == 1 
-    @test minimum(DD[:B]) == -1 
-    @test maximum(DD[:B]) == 1 
+    @test minimum(DD[:A]) == -1
+    @test maximum(DD[:A]) == 1
+    @test minimum(DD[:B]) == -1
+    @test maximum(DD[:B]) == 1
 
     DD = deepcopy(D)
     fixedrange!(DD, -1, 1, [:A, :B, :C])
-    @test minimum(DD[:A]) == -1 
-    @test maximum(DD[:A]) == 1 
-    @test minimum(DD[:B]) == -1 
-    @test maximum(DD[:B]) == 1 
+    @test minimum(DD[:A]) == -1
+    @test maximum(DD[:A]) == 1
+    @test minimum(DD[:B]) == -1
+    @test maximum(DD[:B]) == 1
 
     DD = deepcopy(D_NA)
     fixedrange!(DD, -1, 1, [:A, :B, :C])
-    @test minimum(DD[:B]) == -1 
-    @test maximum(DD[:B]) == 1 
+    @test minimum(DD[:B]) == -1
+    @test maximum(DD[:B]) == 1
 
     DD = deepcopy(D)
     fixedrange!(DD, -1, 1, [0,1], [1,10])
-    @test minimum(DD[:B]) == -1 
-    @test maximum(DD[:B]) == 1 
+    @test minimum(DD[:B]) == -1
+    @test maximum(DD[:B]) == 1
 end

--- a/test/tst_standardize.jl
+++ b/test/tst_standardize.jl
@@ -1,9 +1,8 @@
 X = collect(Float64, reshape(1:40, 10, 4))
 x = rand(10) * 10
 
-D = DataFrame(A=rand(10), B=collect(1:10), C=[hex(x) for x in 11:20])
-D_NA = deepcopy(D)
-allowmissing!(D_NA, :A)
+D = DataFrame(A=rand(10), B=1:10, C=string.(11:20; base=16))
+D_NA = allowmissing!(copy(D))
 D_NA[1, :A] = missing
 
 @testset "Array" begin
@@ -27,92 +26,92 @@ D_NA[1, :A] = missing
 
     xx = deepcopy(x)
     mu = deepcopy(x) .- 1
-    sigma = ones(x)
+    sigma = ones(size(x))
     mu, sigma = standardize!(xx, mu, sigma, obsdim=1)
     @test mean(xx) ≈ 1
 
     # Rescale Matrix
     XX = deepcopy(X)
     standardize!(XX)
-    @test abs(sum(mean(XX, 2))) <= 10e-10
-    @test std(XX, 2) ≈ ones(size(X, 1))
+    @test abs(sum(mean(XX; dims=2))) <= 10e-10
+    @test std(XX; dims=2) ≈ ones(size(X, 1))
 
     XX = deepcopy(X)
     standardize!(XX, obsdim=2)
-    @test abs(sum(mean(XX, 2))) <= 10e-10
-    @test std(XX, 2) ≈ ones(size(X, 1))
+    @test abs(sum(mean(XX; dims=2))) <= 10e-10
+    @test std(XX; dims=2) ≈ ones(size(X, 1))
 
     XX = deepcopy(X)
     standardize!(XX, obsdim=1)
-    @test abs(sum(mean(XX, 1))) <= 10e-10
-    @test vec(std(XX, 1)) ≈ ones(size(X, 2))
+    @test abs(sum(mean(XX; dims=1))) <= 10e-10
+    @test vec(std(XX; dims=1)) ≈ ones(size(X, 2))
 
     XX = deepcopy(X)
-    mu = vec(mean(XX, 1))
-    sigma = vec(std(XX, 1))
+    mu = vec(mean(XX; dims=1))
+    sigma = vec(std(XX; dims=1))
     standardize!(XX, mu, sigma, obsdim=1)
-    @test abs(sum(mean(XX, 1))) <= 10e-10
+    @test abs(sum(mean(XX; dims=1))) <= 10e-10
 
     XX = deepcopy(X)
-    mu = vec(mean(XX, 2))
-    sigma = vec(std(XX, 2))
+    mu = vec(mean(XX; dims=2))
+    sigma = vec(std(XX; dims=2))
     standardize!(XX, mu, sigma, obsdim=2)
-    @test abs(sum(mean(XX, 2))) <= 10e-10
+    @test abs(sum(mean(XX; dims=2))) <= 10e-10
 
     XX = deepcopy(X)
     flt = [1,2]
     standardize!(XX, obsdim=1, operate_on=flt)
-    @test abs(sum(mean(XX[:,flt], 1))) <= 10e-10
-    @test vec(std(XX[:,flt], 1)) ≈ ones(2)
+    @test abs(sum(mean(XX[:,flt]; dims=1))) <= 10e-10
+    @test vec(std(XX[:,flt]; dims=1)) ≈ ones(2)
     @test all(X[:,[3,4]] .== XX[:,[3,4]])
 
     XX = deepcopy(X)
     flt = [2,8]
-    mu = vec(mean(XX, 2))
-    sigma = vec(std(XX, 2))
+    mu = vec(mean(XX; dims=2))
+    sigma = vec(std(XX; dims=2))
     standardize!(XX, mu[flt], sigma[flt], obsdim=2, operate_on=flt)
-    @test abs(sum(mean(XX[flt,:], 2))) <= 10e-10
+    @test abs(sum(mean(XX[flt,:]; dims=2))) <= 10e-10
 
     scaler = StandardScaler(X)
     XX = transform(X, scaler)
-    @test abs(sum(mean(XX, 2))) <= 10e-10
-    @test std(XX, 2) ≈ ones(size(X, 1))
+    @test abs(sum(mean(XX; dims=2))) <= 10e-10
+    @test std(XX; dims=2) ≈ ones(size(X, 1))
 
     scaler = fit(StandardScaler, X)
     XX = transform(X, scaler)
-    @test abs(sum(mean(XX, 2))) <= 10e-10
-    @test std(XX, 2) ≈ ones(size(X, 1))
+    @test abs(sum(mean(XX; dims=2))) <= 10e-10
+    @test std(XX; dims=2) ≈ ones(size(X, 1))
 
     Xi = round.(Int, X)
     XX = transform(Xi, scaler)
-    @test abs(sum(mean(XX, 2))) <= 10e-10
-    @test std(XX, 2) ≈ ones(size(X, 1))
+    @test abs(sum(mean(XX; dims=2))) <= 10e-10
+    @test std(XX; dims=2) ≈ ones(size(X, 1))
 
     XX, scaler = fit_transform(StandardScaler, X)
-    @test abs(sum(mean(XX, 2))) <= 10e-10
-    @test std(XX, 2) ≈ ones(size(X, 1))
+    @test abs(sum(mean(XX; dims=2))) <= 10e-10
+    @test std(XX; dims=2) ≈ ones(size(X, 1))
 
     XX = deepcopy(X)
     scaler = fit_transform!(StandardScaler, XX)
-    @test abs(sum(mean(XX, 2))) <= 10e-10
-    @test std(XX, 2) ≈ ones(size(X, 1))
+    @test abs(sum(mean(XX; dims=2))) <= 10e-10
+    @test std(XX; dims=2) ≈ ones(size(X, 1))
 
     scaler = fit(StandardScaler, X, obsdim=2)
     XX = transform(X, scaler)
-    @test abs(sum(mean(XX, 2))) <= 10e-10
-    @test std(XX, 2) ≈ ones(size(X, 1))
+    @test abs(sum(mean(XX; dims=2))) <= 10e-10
+    @test std(XX; dims=2) ≈ ones(size(X, 1))
 
     scaler = fit(StandardScaler, X, obsdim=1)
     XX = transform(X, scaler)
-    @test abs(sum(mean(XX, 1))) <= 10e-10
-    @test vec(std(XX, 1)) ≈ ones(size(X, 2))
+    @test abs(sum(mean(XX; dims=1))) <= 10e-10
+    @test vec(std(XX; dims=1)) ≈ ones(size(X, 2))
 
     flt = [1,4]
     scaler = fit(StandardScaler, X, obsdim=1, operate_on=flt)
     XX = transform(X, scaler)
     xx = transform(vec(X[1,:]), scaler)
-    @test abs(sum(mean(XX[:,flt], 1))) <= 10e-10
-    @test vec(std(XX[:,flt], 1)) ≈ ones(size(X[:,flt], 2))
+    @test abs(sum(mean(XX[:,flt]; dims=1))) <= 10e-10
+    @test vec(std(XX[:,flt]; dims=1)) ≈ ones(size(X[:,flt], 2))
     @test all(xx .== XX[1,:])
 
     XX = deepcopy(X)
@@ -121,8 +120,8 @@ D_NA[1, :A] = missing
     scaler = fit(StandardScaler, X, obsdim=1, operate_on=flt)
     transform!(XX, scaler)
     transform!(xx, scaler)
-    @test abs(sum(mean(XX[:,flt], 1))) <= 10e-10
-    @test vec(std(XX[:,flt], 1)) ≈ ones(size(X[:,flt], 2))
+    @test abs(sum(mean(XX[:,flt]; dims=1))) <= 10e-10
+    @test vec(std(XX[:,flt]; dims=1)) ≈ ones(size(X[:,flt], 2))
     @test all(xx .== XX[1,:])
 end
 
@@ -158,7 +157,7 @@ end
     # skip columns that contain NA values
     DD = deepcopy(D_NA)
     mu, sigma = standardize!(DD)
-    @test isna(DD[1, :A])
+    @test ismissing(DD[1, :A])
     @test all(DD[2:end, :A] .== D_NA[2:end, :A])
     @test abs(mean(DD[:B])) < 10e-10
     @test abs(std(DD[:B])) - 1 < 10e-10


### PR DESCRIPTION
This is a big PR to work with broadly speaking current versions of all packages.

It deals with:
 -  everything now uses a `dims` kwarg.
 - `DataFrames` now often have columns that are of `eltype`  being `Union{Missing,T}` even if they have no missing values
 - some extra stuff for `expand_basis` with how it determines the result type. (this could be generalised but not today).
 - generally make things pass in 1.0

